### PR TITLE
Fixed bug with `ecojobs.xpmultiplier.*`

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecojobs/jobs/Job.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecojobs/jobs/Job.kt
@@ -511,7 +511,9 @@ private fun Player.cacheJobExperienceMultiplier(): Double {
     for (permissionAttachmentInfo in this.effectivePermissions) {
         val permission = permissionAttachmentInfo.permission
         if (permission.startsWith(prefix)) {
-            return ((permission.substring(permission.lastIndexOf(".") + 1).toDoubleOrNull() ?: 100.0) / 100) + 1
+            (permission.substring(permission.lastIndexOf(".") + 1).toDoubleOrNull())?.let{
+                return (it / 100) + 1
+            }
         }
     }
 


### PR DESCRIPTION
If you have set a `ecojobs.xpmultiplier.*` wildcard permission, logic will evaluate it as valid XpMultiplier permission (at least in LuckPerms). That leads to `2x` multiplier. This fixes it by checking that value after `ecojobs.xpmultiplier.` is number, before setting it as multiplier.