### PR TITLE
Fix Shopkeepers bug

### DIFF
--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -21,6 +21,9 @@ softdepend:
   - Boosters
   - EcoSkills
   - Reforges
+loadbefore:
+  - EcoEnchants
+
 commands:
   ecojobs:
     description: Base Command


### PR DESCRIPTION
During initialization, Shopkeepers fails to recognize add-on enchantments from EcoEnchants and will replace any enchanted books with these add-on enchants as a blank enchanted book, this solves the issue.