### PR TITLE
Wrong usage of a filter

### DIFF
--- a/eco-core/core-plugin/src/main/resources/jobs/miner.yml
+++ b/eco-core/core-plugin/src/main/resources/jobs/miner.yml
@@ -74,15 +74,17 @@ level-xp-requirements:
 xp-gain-methods:
   - trigger: mine_block
     multiplier: 0.5
-    conditions: [ ]
-    filters:
-      items:
-        - "*wooden_pickaxe"
-        - "*stone_pickaxe"
-        - "*iron_pickaxe"
-        - "*golden_pickaxe"
-        - "*diamond_pickaxe"
-        - "*netherite_pickaxe"
+    filters: [ ]
+    conditions:
+      - id: in_mainhand
+        args:
+          items:
+            - "*wooden_pickaxe"
+            - "*stone_pickaxe"
+            - "*iron_pickaxe"
+            - "*golden_pickaxe"
+            - "*diamond_pickaxe"
+            - "*netherite_pickaxe"
 
 level-placeholders:
   - id: "money"
@@ -109,14 +111,16 @@ effects:
     args:
       every: "ceil(10 - %level% / 10)"
       amount: "0.4 * %level%"
-    filters:
-      items:
-        - "*wooden_pickaxe"
-        - "*stone_pickaxe"
-        - "*iron_pickaxe"
-        - "*golden_pickaxe"
-        - "*diamond_pickaxe"
-        - "*netherite_pickaxe"
+    conditions:
+      - id: in_mainhand
+        args:
+          items:
+            - "*wooden_pickaxe"
+            - "*stone_pickaxe"
+            - "*iron_pickaxe"
+            - "*golden_pickaxe"
+            - "*diamond_pickaxe"
+            - "*netherite_pickaxe"
     triggers:
       - mine_block
 


### PR DESCRIPTION
This job had the filter "items" to filter pickaxes, which doesn't work in this case. This essentially means that the players would be able to earn money and xp by breaking a block in any way.

Changed it to the in_mainhand condition.