### PR TITLE
New xp methods

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ allprojects {
     }
 
     dependencies {
-        compileOnly("com.willfp:eco:6.55.0")
+        compileOnly("com.willfp:eco:6.56.0")
         compileOnly("org.jetbrains:annotations:23.0.0")
         compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.1.0")
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecojobs/api/EcoJobsAPI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecojobs/api/EcoJobsAPI.kt
@@ -140,7 +140,7 @@ fun OfflinePlayer.resetJob(job: Job) {
 /**
  * Get the experience required to advance to the next level.
  */
-fun OfflinePlayer.getJobXPRequired(job: Job) = job.getExpForLevel(this.getJobLevel(job) + 1)
+fun OfflinePlayer.getJobXPRequired(job: Job) = job.getFormattedExpForLevel(this.getJobLevel(job) + 1)
 
 /**
  * Get progress to next level between 0 and 1, where 0 is none and 1 is complete.

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecojobs/jobs/JobXPAccumulator.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecojobs/jobs/JobXPAccumulator.kt
@@ -1,9 +1,12 @@
 package com.willfp.ecojobs.jobs
 
+import com.github.benmanes.caffeine.cache.Caffeine
 import com.willfp.ecojobs.api.giveJobExperience
 import com.willfp.ecojobs.api.hasJobActive
 import com.willfp.libreforge.counters.Accumulator
 import org.bukkit.entity.Player
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
 
 class JobXPAccumulator(
     private val job: Job
@@ -15,4 +18,45 @@ class JobXPAccumulator(
 
         player.giveJobExperience(job, count)
     }
+}
+
+private val expMultiplierCache = Caffeine.newBuilder().expireAfterWrite(10, TimeUnit.SECONDS).build<Player, Double> {
+    it.cacheJobExperienceMultiplier()
+}
+
+val Player.jobExperienceMultiplier: Double
+    get() = expMultiplierCache.get(this)
+
+private fun Player.cacheJobExperienceMultiplier(): Double {
+    if (this.hasPermission("ecojobs.xpmultiplier.quadruple")) {
+        return 4.0
+    }
+
+    if (this.hasPermission("ecojobs.xpmultiplier.triple")) {
+        return 3.0
+    }
+
+    if (this.hasPermission("ecojobs.xpmultiplier.double")) {
+        return 2.0
+    }
+
+    if (this.hasPermission("ecojobs.xpmultiplier.50percent")) {
+        return 1.5
+    }
+
+    return 1 + getNumericalPermission("ecojobs.xpmultiplier", 0.0) / 100
+}
+
+fun Player.getNumericalPermission(permission: String, default: Double): Double {
+    var highest: Double? = null
+
+    for (permissionAttachmentInfo in this.effectivePermissions) {
+        val perm = permissionAttachmentInfo.permission
+        if (perm.startsWith(permission)) {
+            val found = perm.substring(perm.lastIndexOf(".") + 1).toDoubleOrNull() ?: continue
+            highest = max(highest ?: Double.MIN_VALUE, found)
+        }
+    }
+
+    return highest ?: default
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecojobs/util/LevelInjectable.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecojobs/util/LevelInjectable.kt
@@ -1,0 +1,27 @@
+package com.willfp.ecojobs.util
+
+import com.willfp.eco.core.placeholder.InjectablePlaceholder
+import com.willfp.eco.core.placeholder.PlaceholderInjectable
+import com.willfp.eco.core.placeholder.StaticPlaceholder
+
+class LevelInjectable(
+    level: Int
+) : PlaceholderInjectable {
+    private val placeholders = listOf(
+        StaticPlaceholder(
+            "level"
+        ) { level.toString() }
+    )
+
+    override fun getPlaceholderInjections(): List<InjectablePlaceholder> {
+        return placeholders
+    }
+
+    override fun addInjectablePlaceholder(p0: Iterable<InjectablePlaceholder>) {
+        return
+    }
+
+    override fun clearInjectedPlaceholders() {
+        return
+    }
+}

--- a/eco-core/core-plugin/src/main/resources/jobs/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/jobs/_example.yml
@@ -39,7 +39,15 @@ leave-price:
 leave-lore:
   - " &8» This will cost %leave_price%"
 
-# The xp requirements for each job level - add new levels by adding more to this list
+# There are two ways to specify level XP requirements:
+#  1. A formula to calculate for infinite levels
+#  2. A list of XP requirements for each level
+
+# Formula
+# xp-formula: (2 ^ %level%) * 25
+# max-level: 100 # The max level of the job
+
+# List
 level-xp-requirements:
   - 100
   - 120


### PR DESCRIPTION
Bumped eco version to support modern placeholder context
Added support for `max-level` and `xp-formula` config args to bring the product standard in line with EcoSkills
Updated example.yml with new args

Tested fully, this works exactly as EcoSkills does.
Just check the code over, but most of it comes from EcoSkills anyway